### PR TITLE
Move condition and mutation spec to separate document

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -147,18 +147,19 @@ The complete list of available operators is shown in the following table, but yo
 
 Operator | Meaning
 :--------|:--------
-$eq, $equal, = | Is equal to. 
-$ne, $neq, != | Not equal to. 
-$lt, $less, < | Less than. Should work for either strings or numbers, but comparing strings to numbers is not defined.
-$lte, $le, <= | Less than or equal.
-$gt, $greater, > | Greater than.
-$ge, $gte, >= | Greater than or equal
-$between | The value of the field should be a list of two values. {x: {$between:[u,v]}} is equivalent to {x: {$ge:u}, x:{$le:v}}.
-$in | The value of the field is in a literal list. {x: {$in: [1,2,34]}} is true if x is any of 1, 2 or 34.
-!$in | Not in.
-$exists | The field exists or not according to the the value supplied. Note that missing is different from null.
-$like, $matches | The value of the field matches a regular expression.
-!$like, !$matches | The value of the field does not match a regular expression.
+`$eq, $equal, =` | Is equal to. 
+`$ne, $neq, !=` | Not equal to. 
+`$lt, $less, <` | Less than. Should work for either strings or numbers, but comparing strings to numbers is not defined.
+`$lte, $le, <=` | Less than or equal.
+`$gt, $greater, >` | Greater than.
+`$ge, $gte, >=` | Greater than or equal
+`$between` | The value of the field should be a list of two values. The expression `{"x": {"$between":[u,v]}}` is equivalent to `{"x": {"$and":[{$ge:u}, {$le:v}]} }`.
+`$in` | The value of the field is in a literal list. {x: {$in: [1,2,34]}} is true if x is any of 1, 2 or 34.
+`!$in` | Not in.
+`$exists` | The field exists or not according to the the value supplied. Note that missing is different from null.
+`$like, $matches` | The value of the field matches a regular expression.
+`!$like, !$matches` | The value of the field does not match a regular expression.
+`$and`, `$or` | Combining forms that combine multiple conditions. The argument is a list of condition expressions. 
 ---------------------	
 
 If you want to set a condition on multiple fields, simply include all of the tests in a single object
@@ -168,7 +169,7 @@ If you want to set a condition on multiple fields, simply include all of the tes
 
 Note that if you need multiple conditions on a single field, you can use the `$and` and `$or` combining forms:
 ```json
-{ "country" : {"$or":{"China", "US"}, "age": {"$and":{"$ge":30, "$lt":40} } } 
+{ "country" : {"$or":{"China", "US"}, "age": {"$and":[{"$ge":30}, {"$lt":40}] } } 
 ```
 
 In contrast, if you want any of several conditions to be satisfied, simply put all the alternatives in a list.

--- a/spec.md
+++ b/spec.md
@@ -117,86 +117,30 @@ For example, equality with a scalar value can have a short-cut expression:
 { "country" : "China" } // country == "China"
 ```
 
-But testing for equality with structures is not allowed:
-
-~~`{ "country" : ["China", "United States"] }`~~
-
-~~`{ "country" : {"bag": "China"} }`~~
-
-Instead, do this:
+Test for structured values like this:
 
 ```json
 { "country" : {"$eq": ["China","United States"]} } 
 ```
 
-Other tests are also available
+Many other tests are also available.  See
+the wiki page on [the condition micro language](https://github.com/mapr-demos/js-bindings/wiki/Condition-Micro-Language)
+for more details.
 
-```json
-{ "age" : { "$gt" : 34 } } // age > 34
-{ "age" : { "$gte" : 34 } } // age >= 34
-{ "age" : { "$lt" : 34 } } // age < 34
-{ "age" : { "$lte" : 34 } } // age <= 34
-{ "age" : { "$neq" : 34 } } // age != 34
-{ "age" : { "$between" : [30,40] } } // BETWEEN 30 and 40 (inclusive)
-{ "age" : { "$in" : [20,25,30] } } // IN [20, 25, 30]
-{ "age" : { "$exists" : true} }
-{ "age" : { "$exists" : false} }
-```
-
-The complete list of available operators is shown in the following table, but you should note that there is no implicit conversion of types done. Note also that comparison with null is done as in Java, not as in SQL.  This means that null == null.
-
-Operator | Meaning
-:--------|:--------
-`$eq, $equal, =` | Is equal to. 
-`$ne, $neq, !=` | Not equal to. 
-`$lt, $less, <` | Less than. Should work for either strings or numbers, but comparing strings to numbers is not defined.
-`$lte, $le, <=` | Less than or equal.
-`$gt, $greater, >` | Greater than.
-`$ge, $gte, >=` | Greater than or equal
-`$between` | The value of the field should be a list of two values. The expression `{"x": {"$between":[u,v]}}` is equivalent to `{"x": {"$and":[{$ge:u}, {$le:v}]} }`.
-`$in` | The value of the field is in a literal list. {x: {$in: [1,2,34]}} is true if x is any of 1, 2 or 34.
-`!$in` | Not in.
-`$exists` | The field exists or not according to the the value supplied. Note that missing is different from null.
-`$like, $matches` | The value of the field matches a regular expression.
-`!$like, !$matches` | The value of the field does not match a regular expression.
-`$and`, `$or` | Combining forms that combine multiple conditions. The argument is a list of condition expressions. 
----------------------	
-
-If you want to set a condition on multiple fields, simply include all of the tests in a single object
-```json
-{ "country" : "China", "age" : 34 } // country = "China" AND age = 34
-```
-
-Note that if you need multiple conditions on a single field, you can use the `$and` and `$or` combining forms:
-```json
-{ "country" : {"$or":{"China", "US"}, "age": {"$and":[{"$ge":30}, {"$lt":40}] } } 
-```
-
-In contrast, if you want any of several conditions to be satisfied, simply put all the alternatives in a list.
-```json
-[ condition1, condition2, ... ] // condition1 OR condition2
-```
-Extension of this mechanism to other tests is an area of active discussion.
 ## Mutation
-The mutation object is sent to the server and all operations are used on the server side. 
-```json
-{"field" : { "$set" : "value"}  }
-{"age" : { "$set" : 34}  }  // set age to 34
-{"age" : { "$set" : 34} , "country" : { "$set": "USA"}  }  // set age to 34 and country to USA
-{ "interests" : { "$set" : ["x", "y"] } } // set interests to an array
-{ "address" : { "$set" : { "t" : "home"} } } // set address to an Object
 
-{"field" : { "$setOrReplace" : "value"}  }
-{"age" : { "$setOrReplace" : 34}  }  // set age to 34
-{"age" : { "$setOrReplace" : 34, "country" : { "$setOrReplace" : "USA"}  }  // set age to 34 and country to USA
+In order to change a record, you need to create a mutation object and
+use it in an update command. The mutation object is sent to the server
+and the actual update is done on the server side.
 
-{ "field" : { "$append" : "value" }}
-{ "name" :  { "$append" : "Doe" }} //  append Doe to the string if string or array if array eg: "John" = "JoeDoe" OR ["John"] = ["John" , "Doe"]
+Mutations are specified in a micro-language similar to the condition
+micro-language. If you want to set a field to a scalar value like a
+number or a string, you can simply say something like `{"age":
+34}`. If you want to do something more elaborate, you need to replace
+the value of the field with an update expression. The most common
+update expression is something like `{"$setOrReplace": ['a','b']}` but
+you could also append a string to a field value, increment a number or
+delete the field entirely.
 
-{"field" : { "$setOrReplace" : "value"}  }
-{"age" : { "$setOrReplace" : 34}  }  // set age to 34
-{"age" : { "$setOrReplace" : 34, "country" : { "$setOrReplace" : "USA"}  }  // set age to 34 and country to USA
-
-{"field" : { "$inc" : value } }
-{"age" : { "$inc" : 1 } } //  increment one value by a specified amount
-```
+See the wiki page on the [mutation micro language](https://github.com/mapr-demos/js-bindings/wiki/Mutation-micro-language)
+for more details.


### PR DESCRIPTION
I am factoring out the condition and mutation micro-specs so that the python and JS specs can share the same documents. Keeping the two cases in synch is too difficult otherwise.
